### PR TITLE
mainBundle这种方法无法在将LCActionSheet作为Framework时正确找到资源包路径

### DIFF
--- a/LCActionSheet/LCActionSheet.m
+++ b/LCActionSheet/LCActionSheet.m
@@ -177,7 +177,7 @@
         [titleBgView addSubview:label];
     }
     
-    NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"LCActionSheet" ofType:@"bundle"];
+    NSString *bundlePath = [[NSBundle bundleForClass:self.class] pathForResource:@"LCActionSheet" ofType:@"bundle"];
     
     if (self.buttonTitles.count) {
         


### PR DESCRIPTION
Hi，采用Swift加Pod模式，发下bundle加载不正确，导致后续图片无法被正常加载，用此法修改就OK了
