### PR TITLE
修复在 iOS8 及以下的系统中，关闭 ActionSheet 后旋转屏幕出现的崩溃

### DIFF
--- a/Sources/LCActionSheet.m
+++ b/Sources/LCActionSheet.m
@@ -209,6 +209,10 @@
     return self;
 }
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (void)setupView {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidChangeStatusBarOrientation)


### PR DESCRIPTION
https://developer.apple.com/library/content/releasenotes/Foundation/RN-Foundation/index.html#10_11NotificationCenter

iOS9 以后当对象被释放掉后才会自动 removeObserver。 在 iOS8 及以下需要在 dealloc 时手动 remove。

如果不 remove，在 iOS8 及以下系统上 LCActionSheet 对象被释放掉以后仍旧会受到通知，会产生崩溃。