### PR TITLE
Add a prefix to UIImage category method

### DIFF
--- a/Sources/LCActionSheet.m
+++ b/Sources/LCActionSheet.m
@@ -336,7 +336,7 @@
     cancelButton.titleLabel.font = self.buttonFont;
     [cancelButton setTitle:self.cancelButtonTitle forState:UIControlStateNormal];
     [cancelButton setTitleColor:self.buttonColor forState:UIControlStateNormal];
-    [cancelButton setBackgroundImage:[UIImage imageWithColor:self.separatorColor]
+    [cancelButton setBackgroundImage:[UIImage lc_imageWithColor:self.separatorColor]
                             forState:UIControlStateHighlighted];
     [cancelButton addTarget:self
                      action:@selector(cancelButtonClicked)
@@ -546,7 +546,7 @@
     
     self.lineView.backgroundColor = separatorColor;
     self.divisionView.backgroundColor = separatorColor;
-    [self.cancelButton setBackgroundImage:[UIImage imageWithColor:separatorColor]
+    [self.cancelButton setBackgroundImage:[UIImage lc_imageWithColor:separatorColor]
                                  forState:UIControlStateHighlighted];
     [self.tableView reloadData];
 }

--- a/Sources/UIImage+LCActionSheet.h
+++ b/Sources/UIImage+LCActionSheet.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Create a image with the color.
  */
-+ (nullable instancetype)imageWithColor:(UIColor *)color;
++ (nullable instancetype)lc_imageWithColor:(UIColor *)color;
 
 @end
 

--- a/Sources/UIImage+LCActionSheet.m
+++ b/Sources/UIImage+LCActionSheet.m
@@ -29,7 +29,7 @@
 
 @implementation UIImage (LCActionSheet)
 
-+ (instancetype)imageWithColor:(UIColor *)color {
++ (instancetype)lc_imageWithColor:(UIColor *)color {
     CGRect rect = CGRectMake(0.0f, 0.0f, 2.0f, 2.0f);
     
     UIGraphicsBeginImageContext(rect.size);


### PR DESCRIPTION
修复 在swift中使用，本地存在相同的类别，导致编译错误的问题。