### PR TITLE
Changed: change windowLevel to UIWindowAlert

### DIFF
--- a/Sources/LCActionSheet.m
+++ b/Sources/LCActionSheet.m
@@ -764,7 +764,7 @@
     viewController.statusBarStyle = [UIApplication sharedApplication].statusBarStyle;
     
     UIWindow *window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-    window.windowLevel = UIWindowLevelStatusBar;
+    window.windowLevel = UIWindowLevelAlert;
     window.rootViewController = viewController;
     [window makeKeyAndVisible];
     self.window = window;


### PR DESCRIPTION
make window level to `UIWindowAlert`  for display correctly in a presented ViewController
(and more reasonable to use `UIWindowAlert` because it's an alert)